### PR TITLE
Update HybridCache.swift for iOS

### DIFF
--- a/Source/iOS/HybridCache.swift
+++ b/Source/iOS/HybridCache.swift
@@ -6,81 +6,91 @@ import UIKit
  Subscribes to system notifications to clear expired cached objects.
  */
 public class HybridCache: BasicHybridCache {
-
-  // MARK: - Inititalization
-
-  /**
-   Creates a new instance of BasicHybridCache and subscribes to system notifications.
-
-   - Parameter name: A name of the cache
-   - Parameter config: Cache configuration
-   */
-  public override init(name: String, config: Config = Config.defaultConfig) {
-    super.init(name: name, config: config)
-
-    let notificationCenter = NotificationCenter.default
     
-    notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationDidReceiveMemoryWarning),
-      name: Notification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
-    notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationWillTerminate),
-      name: Notification.Name.UIApplicationWillTerminate, object: nil)
-    notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationDidEnterBackground),
-      name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
-  }
-
-  /**
-   Removes notification center observer.
-   */
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
-  // MARK: - Notifications
-
-  /**
-   Clears expired cache items when the app recieves memory warning.
-   */
-  func applicationDidReceiveMemoryWarning() {
-    frontStorage.clearExpired(nil)
-  }
-
-  /**
-   Clears expired cache items when the app terminates.
-   */
-  func applicationWillTerminate() {
-    backStorage.clearExpired(nil)
-  }
-
-  /**
-   Clears expired cache items when the app enters background.
-   */
-  func applicationDidEnterBackground() {
-    let application = UIApplication.shared
-    var backgroundTask: UIBackgroundTaskIdentifier?
-
-    backgroundTask = application.beginBackgroundTask (expirationHandler: { [weak self] in
-      guard let weakSelf = self, let backgroundTask = backgroundTask else { return }
-      var mutableBackgroundTask = backgroundTask
-
-      weakSelf.endBackgroundTask(&mutableBackgroundTask)
-    })
-
-    backStorage.clearExpired { [weak self] in
-      guard let weakSelf = self, let backgroundTask = backgroundTask else { return }
-      var mutableBackgroundTask = backgroundTask
-
-      DispatchQueue.main.async {
-        weakSelf.endBackgroundTask(&mutableBackgroundTask)
-      }
+    // MARK: - Inititalization
+    
+    /**
+     Creates a new instance of BasicHybridCache and subscribes to system notifications.
+     
+     - Parameter name: A name of the cache
+     - Parameter config: Cache configuration
+     */
+    public override init(name: String, config: Config = Config.defaultConfig) {
+        super.init(name: name, config: config)
+        
+        let notificationCenter = NotificationCenter.default
+        
+        notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationDidReceiveMemoryWarning),
+                                       name: Notification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationWillTerminate),
+                                       name: Notification.Name.UIApplicationWillTerminate, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(HybridCache.applicationDidEnterBackground),
+                                       name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
     }
-  }
-
-  /**
-   Ends given background task.
-   - Parameter task: A UIBackgroundTaskIdentifier
-   */
-  func endBackgroundTask(_ task: inout UIBackgroundTaskIdentifier) {
-    UIApplication.shared.endBackgroundTask(task)
-    task = UIBackgroundTaskInvalid
-  }
+    
+    /**
+     Removes notification center observer.
+     */
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Notifications
+    
+    /**
+     Clears expired cache items when the app recieves memory warning.
+     */
+    func applicationDidReceiveMemoryWarning() {
+        frontStorage.clearExpired(nil)
+    }
+    
+    /**
+     Clears expired cache items when the app terminates.
+     */
+    func applicationWillTerminate() {
+        backStorage.clearExpired(nil)
+    }
+    
+    func sharedApplicationOrNil() -> UIApplication? {
+        let sharedApplicationSelector: Selector = "sharedApplication"
+        guard UIApplication.responds(to: sharedApplicationSelector) else {
+            return nil
+        }
+        guard let unmanagedSharedApplication = UIApplication.perform(sharedApplicationSelector) else {
+            return nil
+        }
+        return unmanagedSharedApplication.takeUnretainedValue() as? UIApplication
+    }
+    
+    /**
+     Clears expired cache items when the app enters background.
+     */
+    func applicationDidEnterBackground() {
+        var backgroundTask: UIBackgroundTaskIdentifier?
+        
+        backgroundTask = sharedApplicationOrNil()?.beginBackgroundTask (expirationHandler: { [weak self] in
+            guard let weakSelf = self, let backgroundTask = backgroundTask else { return }
+            var mutableBackgroundTask = backgroundTask
+            
+            weakSelf.endBackgroundTask(&mutableBackgroundTask)
+        })
+        
+        backStorage.clearExpired { [weak self] in
+            guard let weakSelf = self, let backgroundTask = backgroundTask else { return }
+            var mutableBackgroundTask = backgroundTask
+            
+            DispatchQueue.main.async {
+                weakSelf.endBackgroundTask(&mutableBackgroundTask)
+            }
+        }
+    }
+    
+    /**
+     Ends given background task.
+     - Parameter task: A UIBackgroundTaskIdentifier
+     */
+    func endBackgroundTask(_ task: inout UIBackgroundTaskIdentifier) {
+        sharedApplicationOrNil()?.endBackgroundTask(task)
+        task = UIBackgroundTaskInvalid
+    }
 }


### PR DESCRIPTION
`UIApplication.shared` is used in HybridCache.swift, this property is not available for app extensions. ObjC runtime is used to resolve this problem, see `sharedApplicationOrNil()`.